### PR TITLE
Fix list release

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 
 releases_path=https://api.github.com/repos/instrumenta/kubeval/releases
-cmd="curl -s"
-if [ -n "$GITHUB_API_TOKEN" ]; then
-  cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"
+if [ -n "${GITHUB_API_TOKEN}" ]; then
+  header="-H 'Authorization: token ${GITHUB_API_TOKEN}'"
+else
+  header=''
 fi
-cmd="$cmd $releases_path"
+
+cmd="curl -q ${header} -s ${releases_path}"
 
 # stolen from https://github.com/rbenv/ruby-build/pull/631/files#diff-fdcfb8a18714b33b07529b7d02b54f1dR942
 function sort_versions() {

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-releases_path=https://api.github.com/repos/bitnami-labs/sealed-secrets/releases
+releases_path=https://api.github.com/repos/instrumenta/kubeval/releases
 cmd="curl -s"
 if [ -n "$GITHUB_API_TOKEN" ]; then
   cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"
@@ -14,5 +14,5 @@ function sort_versions() {
 }
 
 # Fetch all tag names, and get only second column. Then remove all unnecesary characters.
-versions=$(eval $cmd | grep -oE "tag_name\": *\".{1,15}\"," | sed 's/tag_name\": *\"v//;s/\",//' | sort_versions)
+versions=$(eval $cmd | grep -oE "tag_name\": \".{1,15}\"," | sed 's/tag_name\": \"//;s/\",//' | sort_versions)
 echo $versions


### PR DESCRIPTION
There was 2 problems:
- the releases_path was not targeting [kubeval repository ](https://github.com/instrumenta/kubeval/releases)
- the sed command that extract the release number was expecting a "v"
  prefix. kubeval follow semver2 and thus does not use any prefix

Install is working fine but you cannot rely on auto completion to know the releases of kubeval you can install.